### PR TITLE
Group not found error logging is now optional

### DIFF
--- a/src/main/java/org/oscm/identity/controller/GroupController.java
+++ b/src/main/java/org/oscm/identity/controller/GroupController.java
@@ -58,7 +58,7 @@ public class GroupController {
   public ResponseEntity getGroup(
       @PathVariable String tenantId,
       @PathVariable String groupName,
-      @RequestParam(value = "logErrors", required = false, defaultValue = "${system.log.errors}")
+      @RequestParam(value = "logErrors", required = false, defaultValue = "true")
           Boolean logErrors,
       @RequestHeader(value = "Authorization") String bearerToken)
       throws JSONException, ResourceNotFoundException {

--- a/src/main/java/org/oscm/identity/error/DefaultExceptionHandler.java
+++ b/src/main/java/org/oscm/identity/error/DefaultExceptionHandler.java
@@ -1,10 +1,12 @@
-/*******************************************************************************
+/**
+ * *****************************************************************************
  *
- *  Copyright FUJITSU LIMITED 2019
+ * <p>Copyright FUJITSU LIMITED 2019
  *
- *  Creation Date: Jun 18, 2019
+ * <p>Creation Date: Jun 18, 2019
  *
- *******************************************************************************/
+ * <p>*****************************************************************************
+ */
 package org.oscm.identity.error;
 
 import lombok.extern.slf4j.Slf4j;
@@ -20,9 +22,6 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import com.jayway.jsonpath.JsonPathException;
-
-
 @ControllerAdvice
 @Slf4j
 public class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
@@ -32,10 +31,7 @@ public class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
 
     log.error(ex.getMessage(), ex);
     ErrorResponse response =
-        ErrorResponse.of()
-            .error("Internal error")
-            .errorDescription(ex.getMessage())
-            .build();
+        ErrorResponse.of().error("Internal error").errorDescription(ex.getMessage()).build();
 
     return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
   }
@@ -69,15 +65,16 @@ public class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
 
     return new ResponseEntity<>(response, ex.getStatusCode());
   }
-  
-  @ExceptionHandler(JsonPathException.class)
-  public ResponseEntity<ErrorResponse> handleJsonError(JsonPathException ex) {
 
-      log.error(ex.getMessage(), ex);
+  @ExceptionHandler(ResourceNotFoundException.class)
+  public ResponseEntity<ErrorResponse> handleJsonError(ResourceNotFoundException ex) {
 
-      ErrorResponse errorResponse = ErrorResponse.of().error("Json parsing error").errorDescription(ex.getMessage()).build();
+    if (ex.isLoggable()) log.error(ex.getMessage(), ex);
 
-      return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    ErrorResponse errorResponse =
+        ErrorResponse.of().error("Requested resource not found").errorDescription(ex.getMessage()).build();
+
+    return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
   }
 
   @Override
@@ -108,11 +105,15 @@ public class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   @ExceptionHandler(TokenValidationException.class)
-  protected ResponseEntity<ErrorResponse> handleTokenValidationException(TokenValidationException ex) {
+  protected ResponseEntity<ErrorResponse> handleTokenValidationException(
+      TokenValidationException ex) {
     log.error(ex.getMessage(), ex);
 
-
-    ErrorResponse errorResponse = ErrorResponse.of().error("Token validation failed").errorDescription(ex.getMessage()).build();
+    ErrorResponse errorResponse =
+        ErrorResponse.of()
+            .error("Token validation failed")
+            .errorDescription(ex.getMessage())
+            .build();
 
     return new ResponseEntity<>(errorResponse, HttpStatus.NOT_ACCEPTABLE);
   }

--- a/src/main/java/org/oscm/identity/error/ResourceNotFoundException.java
+++ b/src/main/java/org/oscm/identity/error/ResourceNotFoundException.java
@@ -1,0 +1,47 @@
+/**
+ * *****************************************************************************
+ *
+ * <p>Copyright FUJITSU LIMITED 2019
+ *
+ * <p>Creation Date: 07-11-2019
+ *
+ * <p>*****************************************************************************
+ */
+package org.oscm.identity.error;
+
+import lombok.Getter;
+
+@Getter
+public class ResourceNotFoundException extends Exception {
+
+  private final boolean isLoggable;
+
+  public ResourceNotFoundException(boolean isLoggable) {
+    this.isLoggable = isLoggable;
+  }
+
+  public ResourceNotFoundException(String message, boolean isLoggable) {
+    super(message);
+    this.isLoggable = isLoggable;
+  }
+
+  public ResourceNotFoundException(String message, Throwable cause, boolean isLoggable) {
+    super(message, cause);
+    this.isLoggable = isLoggable;
+  }
+
+  public ResourceNotFoundException(Throwable cause, boolean isLoggable) {
+    super(cause);
+    this.isLoggable = isLoggable;
+  }
+
+  public ResourceNotFoundException(
+      String message,
+      Throwable cause,
+      boolean enableSuppression,
+      boolean writableStackTrace,
+      boolean isLoggable) {
+    super(message, cause, enableSuppression, writableStackTrace);
+    this.isLoggable = isLoggable;
+  }
+}

--- a/src/main/java/org/oscm/identity/model/response/DefaultResponseMapper.java
+++ b/src/main/java/org/oscm/identity/model/response/DefaultResponseMapper.java
@@ -9,10 +9,10 @@
  */
 package org.oscm.identity.model.response;
 
-import com.jayway.jsonpath.JsonPathException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.oscm.identity.error.ResourceNotFoundException;
 import org.oscm.identity.model.json.*;
 
 import java.util.HashSet;
@@ -84,11 +84,15 @@ public class DefaultResponseMapper implements ResponseMapper {
   }
 
   @Override
-  public UserGroupDTO getGroup(JSONObject json, String requestedGroupName) throws JSONException {
+  public UserGroupDTO getGroup(JSONObject json, String requestedGroupName, boolean isLoggable)
+      throws ResourceNotFoundException, JSONException {
     return convertJsonArrayToGroupSet(json).stream()
         .filter(u -> u.getName().equals(requestedGroupName))
         .findAny()
-        .orElseThrow(() -> new JsonPathException("Group of requested name has not been found"));
+        .orElseThrow(
+            () ->
+                new ResourceNotFoundException(
+                    "Group of requested name has not been found", isLoggable));
   }
 
   @Override

--- a/src/main/java/org/oscm/identity/model/response/ResponseMapper.java
+++ b/src/main/java/org/oscm/identity/model/response/ResponseMapper.java
@@ -1,15 +1,17 @@
-/*******************************************************************************
+/**
+ * *****************************************************************************
  *
- *  Copyright FUJITSU LIMITED 2019
+ * <p>Copyright FUJITSU LIMITED 2019
  *
- *  Creation Date: Jul 26, 2019
+ * <p>Creation Date: Jul 26, 2019
  *
- *******************************************************************************/
-
+ * <p>*****************************************************************************
+ */
 package org.oscm.identity.model.response;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.oscm.identity.error.ResourceNotFoundException;
 import org.oscm.identity.model.json.*;
 
 import java.util.Set;
@@ -67,10 +69,12 @@ public interface ResponseMapper {
    *
    * @param json object to be mapped
    * @param requestedGroupName name of the group that is requested
+   * @param isLoggable determines whether errors thrown in the method should be logged
    * @return object representing User Group
    * @throws JSONException
    */
-  UserGroupDTO getGroup(JSONObject json, String requestedGroupName) throws JSONException;
+  UserGroupDTO getGroup(JSONObject json, String requestedGroupName, boolean isLoggable)
+      throws ResourceNotFoundException, JSONException;
 
   /**
    * maps json object to object representing access token

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,11 @@
 spring.profiles.active=prod
 server.servlet.contextPath=/oscm-identity
 server.port=9091
+http.port=9090
 
+system.log.errors=true
 tenant.config.directory.relative.path=/config/tenants/
 
 auth.signing.algorithm.type=RS256
 
-http.port=9090
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,6 @@ server.servlet.contextPath=/oscm-identity
 server.port=9091
 http.port=9090
 
-system.log.errors=true
 tenant.config.directory.relative.path=/config/tenants/
 
 auth.signing.algorithm.type=RS256

--- a/src/test/java/org/oscm/identity/controller/GroupControllerTest.java
+++ b/src/test/java/org/oscm/identity/controller/GroupControllerTest.java
@@ -265,7 +265,7 @@ public class GroupControllerTest {
 
     // when
     ResponseEntity<UserGroupDTO> response =
-        controller.getGroup(tenantId, userGroupDTO.getName(), bearerToken);
+        controller.getGroup(tenantId, userGroupDTO.getName(), true, bearerToken);
 
     // then
     assertThat(response).extracting(ResponseEntity::getStatusCode).isEqualTo(HttpStatus.OK);

--- a/src/test/java/org/oscm/identity/error/DefaultExceptionHandlerTest.java
+++ b/src/test/java/org/oscm/identity/error/DefaultExceptionHandlerTest.java
@@ -111,7 +111,7 @@ public class DefaultExceptionHandlerTest {
   public void testHandleJsonPathException_InvalidExceptionThrown_properResponseIsReturned() {
 
     // given
-    JsonPathException exception = new JsonPathException("some error message");
+    ResourceNotFoundException exception = new ResourceNotFoundException(true);
 
     // when
     ResponseEntity<ErrorResponse> response = handler.handleJsonError(exception);


### PR DESCRIPTION
**Changes in this Pull Request:**
- exception logging when getting the groups is now optional. This functionality can be configured either globally - in ``application.properties`` file and locally - by adding ``?logErrors=true`` query parameter to the GET request.

**Mandatory checks:**
- [x] latest changes were fetched from the upstream branch before creating this PR (branch is up to date)
- [x] changes were tested manually
- [x] unit tests were properly implemented
- [x] communication about interdependent changes has been sent to the team (if applicable)
- [x] respective Jenkins jobs were referenced in *additional context* section of this PR

**OSCM Build References:**
N/A

Closes #66 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm-identity/73)
<!-- Reviewable:end -->
